### PR TITLE
Fix CachedBadge hooks dependency array

### DIFF
--- a/frontend/src/components/cached_badge.rs
+++ b/frontend/src/components/cached_badge.rs
@@ -34,16 +34,20 @@ const CHECK_DECAGRAM_PATH: &str = "M23 12l-2.44-2.78.34-3.68-3.61-.82-1.89-3.18L
 /// `processing_version` bumps (indicating a worker just finished a video).
 #[function_component(CachedBadge)]
 pub fn cached_badge(props: &Props) -> Html {
+    // Only active in aggressive mode.
+    if props.cache_strategy != "aggressive" {
+        return html! {};
+    }
+
     let fully_cached: UseStateHandle<bool> = use_state(|| false);
 
     {
         let fully_cached = fully_cached.clone();
         let video_id = props.video_id.clone();
         let version = props.processing_version;
-        let is_aggressive = props.cache_strategy == "aggressive";
-        
-        use_effect_with((video_id, version, is_aggressive), move |(video_id, _version, is_aggressive)| {
-            if *is_aggressive {
+        use_effect_with(
+            (video_id.clone(), version),
+            move |(video_id, _version)| {
                 let video_id = video_id.clone();
                 let fully_cached = fully_cached.clone();
                 spawn_local(async move {
@@ -56,13 +60,12 @@ pub fn cached_badge(props: &Props) -> Html {
                         }
                     }
                 });
-            }
-            
-            || ()
-        });
+                || ()
+            },
+        );
     }
 
-    if props.cache_strategy == "aggressive" && *fully_cached {
+    if *fully_cached {
         html! {
             <svg
                 class="cached-badge"


### PR DESCRIPTION
Using clone() inside the effect deps tuple ensures that when the video ID changes, the hook fires correctly without moving the prop string out of the struct context unexpectedly.